### PR TITLE
Update neat.js

### DIFF
--- a/neat.js
+++ b/neat.js
@@ -1074,9 +1074,21 @@
                     } catch (e) {
                         return;
                     }
-                    chrome.tabs.update(tab.id, {
-                        url: decodedurl
-                    });
+                    //Start of patch for using bookmarklets
+                    var expression = 'javascript:*'
+                    var regex = new RegExp(expression);
+                    if (decodedurl.match(regex)){
+                        //bookmarklet
+                        chrome.tabs.executeScript(tab.id, {
+                            code: decodedurl
+                        });
+                    } else {
+                        //url
+                        chrome.tabs.update(tab.id, {
+                            url: decodedurl
+                        });
+                    }
+                    //End of putch for using bookmarklets
                     if (!bookmarkClickStayOpen)
                         setTimeout(window.close, 200);
                 });


### PR DESCRIPTION
**The problem was**: in vBookmarks user's can't use bookmarklets. To verify this just save a bookmark with simple URL
`javascript:(function(){alert('Hello world!')})()`
and try to use it through the vBookmarks and through the standard browser panel. The behavior will be different. From the panel it will work. From the extension will not work.

**The solution is**: The code has been modified to enable the use of bookmarklets through this extension (use was impossible due to the widespread use of function "chrome.tabs.update" for all protocols, even when the javascript protocol is specified in the saved bookmark). The patch code (strings 1077-1091) is not beautiful, but workable. Tested in Google Chrome and Yandex Browser.

Sorry for my english and javascript please. I'm not a programmer and I'm not a linguist to. Thank you for you're work!